### PR TITLE
Support linux desktop tap events

### DIFF
--- a/lib/pressable.dart
+++ b/lib/pressable.dart
@@ -1,6 +1,7 @@
 library;
 
 export 'package:pressable/src/builder.dart';
+export 'package:pressable/src/custom_gesture_detector.dart';
 export 'package:pressable/src/fill.dart';
 export 'package:pressable/src/opacity.dart';
 export 'package:pressable/src/platform.dart';

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pressable/src/base.dart';
+import 'package:pressable/src/custom_gesture_detector.dart';
 
 /// Builds [Widget] inside [PressableBuilder].
 typedef PressableBuilderCallback =
@@ -32,7 +33,7 @@ class _PressableBuilderState extends PressableBaseState<PressableBuilder> {
           (widget.onPressed != null || widget.onLongPressed != null)
               ? SystemMouseCursors.click
               : SystemMouseCursors.basic,
-      child: GestureDetector(
+      child: CustomGestureDetector(
         onTap: widget.onPressed,
         onTapDown: widget.onPressed != null ? onPressStarted : null,
         onTapUp: widget.onPressed != null ? onPressEnded : null,

--- a/lib/src/custom_gesture_detector.dart
+++ b/lib/src/custom_gesture_detector.dart
@@ -15,7 +15,7 @@ class CustomGestureDetector extends StatefulWidget {
     this.onLongPress,
     this.onLongPressStart,
     this.onLongPressEnd,
-    this.behavior,
+    this.behavior = HitTestBehavior.opaque,
     this.excludeFromSemantics = false,
   });
 
@@ -27,7 +27,7 @@ class CustomGestureDetector extends StatefulWidget {
   final VoidCallback? onLongPress;
   final GestureLongPressStartCallback? onLongPressStart;
   final GestureLongPressEndCallback? onLongPressEnd;
-  final HitTestBehavior? behavior;
+  final HitTestBehavior behavior;
   final bool excludeFromSemantics;
 
   @override
@@ -62,7 +62,7 @@ class _CustomGestureDetectorState extends State<CustomGestureDetector> {
       
       // Only trigger fallback if gesture detector didn't handle it
       widget.onTapUp?.call(TapUpDetails(
-        kind: PointerDeviceKind.touch,
+        kind: event.kind,
         globalPosition: event.position,
         localPosition: event.localPosition,
       ));
@@ -114,7 +114,7 @@ class _CustomGestureDetectorState extends State<CustomGestureDetector> {
       onLongPress: widget.onLongPress,
       onLongPressStart: widget.onLongPressStart,
       onLongPressEnd: widget.onLongPressEnd,
-      behavior: widget.behavior ?? HitTestBehavior.opaque,
+      behavior: widget.behavior,
       excludeFromSemantics: widget.excludeFromSemantics,
       child: widget.child,
     );

--- a/lib/src/custom_gesture_detector.dart
+++ b/lib/src/custom_gesture_detector.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+/// A robust gesture detector that combines GestureDetector with fallback pointer handling
+/// for better cross-platform compatibility, especially on Linux desktop touch screens.
+class CustomGestureDetector extends StatefulWidget {
+  const CustomGestureDetector({
+    super.key,
+    required this.child,
+    this.onTap,
+    this.onTapDown,
+    this.onTapUp,
+    this.onTapCancel,
+    this.onLongPress,
+    this.onLongPressStart,
+    this.onLongPressEnd,
+    this.behavior,
+    this.excludeFromSemantics = false,
+  });
+
+  final Widget child;
+  final VoidCallback? onTap;
+  final GestureTapDownCallback? onTapDown;
+  final GestureTapUpCallback? onTapUp;
+  final VoidCallback? onTapCancel;
+  final VoidCallback? onLongPress;
+  final GestureLongPressStartCallback? onLongPressStart;
+  final GestureLongPressEndCallback? onLongPressEnd;
+  final HitTestBehavior? behavior;
+  final bool excludeFromSemantics;
+
+  @override
+  State<CustomGestureDetector> createState() => _CustomGestureDetectorState();
+}
+
+class _CustomGestureDetectorState extends State<CustomGestureDetector> {
+  bool _isPressed = false;
+  int? _activePointerId;
+  bool _gestureHandled = false;
+
+  // Track if we're on a platform that might have touch issues
+  bool get _needsPointerFallback => 
+      defaultTargetPlatform == TargetPlatform.linux;
+
+  void _handlePointerDown(PointerDownEvent event) {
+    if (_needsPointerFallback && _activePointerId == null) {
+      _activePointerId = event.pointer;
+      _isPressed = true;
+      _gestureHandled = false;
+    }
+  }
+
+  void _handlePointerUp(PointerUpEvent event) {
+    if (_needsPointerFallback && 
+        _activePointerId == event.pointer && 
+        _isPressed && 
+        !_gestureHandled) {
+      
+      _activePointerId = null;
+      _isPressed = false;
+      
+      // Only trigger fallback if gesture detector didn't handle it
+      widget.onTapUp?.call(TapUpDetails(
+        kind: PointerDeviceKind.touch,
+        globalPosition: event.position,
+        localPosition: event.localPosition,
+      ));
+      widget.onTap?.call();
+    }
+  }
+
+  void _handlePointerCancel(PointerCancelEvent event) {
+    if (_needsPointerFallback && 
+        _activePointerId == event.pointer && 
+        _isPressed && 
+        !_gestureHandled) {
+      
+      _activePointerId = null;
+      _isPressed = false;
+      widget.onTapCancel?.call();
+    }
+  }
+
+  void _onGestureTapDown(TapDownDetails details) {
+    _gestureHandled = true;
+    widget.onTapDown?.call(details);
+  }
+
+  void _onGestureTapUp(TapUpDetails details) {
+    _gestureHandled = true;
+    _isPressed = false;
+    widget.onTapUp?.call(details);
+  }
+
+  void _onGestureTapCancel() {
+    _gestureHandled = true;
+    _isPressed = false;
+    widget.onTapCancel?.call();
+  }
+
+  void _onGestureTap() {
+    _gestureHandled = true;
+    widget.onTap?.call();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget child = GestureDetector(
+      onTap: widget.onTap != null ? _onGestureTap : null,
+      onTapDown: widget.onTapDown != null ? _onGestureTapDown : null,
+      onTapUp: widget.onTapUp != null ? _onGestureTapUp : null,
+      onTapCancel: widget.onTapCancel != null ? _onGestureTapCancel : null,
+      onLongPress: widget.onLongPress,
+      onLongPressStart: widget.onLongPressStart,
+      onLongPressEnd: widget.onLongPressEnd,
+      behavior: widget.behavior ?? HitTestBehavior.opaque,
+      excludeFromSemantics: widget.excludeFromSemantics,
+      child: widget.child,
+    );
+
+    // Only add pointer fallback on platforms that need it
+    if (_needsPointerFallback) {
+      child = Listener(
+        onPointerDown: _handlePointerDown,
+        onPointerUp: _handlePointerUp,
+        onPointerCancel: _handlePointerCancel,
+        child: child,
+      );
+    }
+
+    return child;
+  }
+}

--- a/lib/src/opacity.dart
+++ b/lib/src/opacity.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pressable/pressable.dart';
 import 'package:pressable/src/base.dart';
+import 'package:pressable/src/custom_gesture_detector.dart';
 
 /// Makes [child] semi-transparent when pressed.
 class PressableOpacity extends StatefulWidget {
@@ -49,7 +50,7 @@ class _PressableOpacityState extends PressableBaseState<PressableOpacity>
           (widget.onPressed != null || widget.onLongPressed != null)
               ? SystemMouseCursors.click
               : SystemMouseCursors.basic,
-      child: GestureDetector(
+      child: CustomGestureDetector(
         onTap: widget.onPressed,
         onTapDown: widget.onPressed != null ? onPressStarted : null,
         onTapUp: widget.onPressed != null ? onPressEnded : null,

--- a/lib/src/scale.dart
+++ b/lib/src/scale.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pressable/pressable.dart';
 import 'package:pressable/src/base.dart';
+import 'package:pressable/src/custom_gesture_detector.dart';
 
 /// Scales [child] down when pressed.
 class PressableScale extends StatefulWidget {
@@ -48,7 +49,7 @@ class _PressableScaleState extends PressableBaseState<PressableScale>
           (widget.onPressed != null || widget.onLongPressed != null)
               ? SystemMouseCursors.click
               : MouseCursor.defer,
-      child: GestureDetector(
+      child: CustomGestureDetector(
         onTap: widget.onPressed,
         onTapDown: widget.onPressed != null ? onPressStarted : null,
         onTapUp: widget.onPressed != null ? onPressEnded : null,


### PR DESCRIPTION
When testing on linux desktop, I noticed the buttons get stuck in pressed state after holding them a few seconds. 
Trying to solve it by adding additional Listener on linux platorm to catch pointers up, down and cancel.